### PR TITLE
 accurate apogee sum detection

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -35,6 +35,7 @@ State::State(double arm_time, double arm_alt, double arm_vel, double arm_acc, do
     this->drogue_channel = &drogue;
     this->main_channel = &main;
     this->sus_channel = &sust;
+    this->apg_detection_sum = 0;
 };
 
 


### PR DESCRIPTION
Initialized the value of apogee detection sum to 0, preventing garbage data from providing faulty apogee confidence. 